### PR TITLE
Tengam

### DIFF
--- a/src/main/java/dandustry/DandustryEventHandler.java
+++ b/src/main/java/dandustry/DandustryEventHandler.java
@@ -66,8 +66,8 @@ public class DandustryEventHandler {
         appendToComponent(COIL_ELECTRIC, wireGtOctal, Pikyonium, Lafium, Signalium, Bedrockium, Quantium);
 
         // Sticks
-        appendToComponent(STICK_MAGNETIC, stickLong, SamariumMagnetic, SamariumMagnetic, KerrBlackHole, KerrBlackHole, KerrBlackHole);
-        appendToComponent(GTValues.IV, STICK_ELECTROMAGNETIC, stickLong, VanadiumGallium, VanadiumGallium, VanadiumGallium, VanadiumGallium, EnrichedNaquadahAlloy, Aluminum, Lumiium, CrystalMatrix, Ledox);
+        appendToComponent(STICK_MAGNETIC, stickLong, TengamAttuned, TengamAttuned, TengamAttuned, KerrBlackHole, KerrBlackHole);
+        appendToComponent(GTValues.IV, STICK_ELECTROMAGNETIC, stickLong, VanadiumGallium, VanadiumGallium, VanadiumGallium, VanadiumGallium, TengamAttuned, TengamAttuned, TengamAttuned, KerrBlackHole, KerrBlackHole);
         appendToComponent(STICK_DISTILLATION, spring, Pikyonium, Lafium, Signalium, Bedrockium, Quantium);
 
         // Not used by base CEu

--- a/src/main/java/dandustry/item/DandustryMaterials.java
+++ b/src/main/java/dandustry/item/DandustryMaterials.java
@@ -116,6 +116,9 @@ public class DandustryMaterials {
     public static Material TransCataExcited;
     public static Material TransCataResplendent;
     public static Material TransResidue;
+    public static Material TengamRaw;
+    public static Material TengamPurified;
+    public static Material TengamAttuned;
 
     public static void registerMaterials() {
 
@@ -1119,5 +1122,37 @@ public class DandustryMaterials {
                 .color(0x4944AF)
                 .fluidTemp(2800000)
                 .build();
+
+        TengamRaw = new Material.Builder(19104, "tengam_raw")
+                .dust(3).ore()
+                .color(0xA0BF60).iconSet(DULL)
+                .fluidTemp(5000)
+                .build()
+                .setFormula("M");
+
+        OreProperty oreProp = TengamRaw.getProperty(PropertyKey.ORE);
+        oreProp.setOreByProducts(IronMagnetic, SteelMagnetic, NeodymiumMagnetic, SamariumMagnetic);
+        oreProp.setWashedIn(Steel);
+        oreProp.setDirectSmeltResult(NeodymiumMagnetic);
+
+        TengamPurified = new Material.Builder(19105, "tengam_purified")
+                .ingot(3).fluid()
+                .color(0xD5FF80).iconSet(SHINY)
+                .flags(STD_METAL)
+                .blastTemp(10800, GasTier.HIGHEST, VA[UV], 5000)
+                .fluidTemp(5000)
+                .build()
+                .setFormula("M");
+
+        TengamAttuned = new Material.Builder(19106, "tengam_attuned")
+                .ingot(3)
+                .color(0xD5FF80).iconSet(MAGNETIC)
+                .flags(STD_METAL, GENERATE_LONG_ROD, IS_MAGNETIC)
+                .components(TengamPurified, 1)
+                .ingotSmeltInto(TengamPurified)
+                .arcSmeltInto(TengamPurified)
+                .macerateInto(TengamPurified)
+                .build();
+        TengamPurified.getProperty(PropertyKey.INGOT).setMagneticMaterial(TengamAttuned);
     }
 }

--- a/src/main/java/dandustry/machine/DandustryRecipeMaps.java
+++ b/src/main/java/dandustry/machine/DandustryRecipeMaps.java
@@ -11,11 +11,12 @@ public class DandustryRecipeMaps {
     // todo overlays, progress bar, sound, finalize slot counts, etc
 
     public static void preInit() {
-        RecipeMaps.MIXER_RECIPES.setMaxInputs(9);
-        RecipeMaps.MIXER_RECIPES.setMaxFluidInputs(3);
-        RecipeMaps.CENTRIFUGE_RECIPES.setMaxOutputs(9);
         RecipeMaps.BLAST_RECIPES.setMaxFluidInputs(2);
         RecipeMaps.BLAST_RECIPES.setMaxFluidOutputs(2);
+        RecipeMaps.CENTRIFUGE_RECIPES.setMaxOutputs(9);
+        RecipeMaps.ELECTROMAGNETIC_SEPARATOR_RECIPES.setMaxOutputs(6);
         RecipeMaps.LASER_ENGRAVER_RECIPES.setMaxInputs(4);
+        RecipeMaps.MIXER_RECIPES.setMaxInputs(9);
+        RecipeMaps.MIXER_RECIPES.setMaxFluidInputs(3);
     }
 }

--- a/src/main/java/dandustry/recipe/DestabilizedMatterChain.java
+++ b/src/main/java/dandustry/recipe/DestabilizedMatterChain.java
@@ -70,11 +70,11 @@ public class DestabilizedMatterChain {
         // Kerr Black Hole
 
         LABORATORY_RECIPES.recipeBuilder()
-                .input(dust, RadoxPolymer).input(dust, TinAlloy, 4)
+                .input(stickLong, TengamAttuned, 2).input(dust, RadoxPolymer).input(dust, TinAlloy, 4)
                 .fluidInputs(AtomicResonanceCatalyst.getFluid(144), ExoticMatter.getFluid(1000), DarkMatter.getFluid(500), RedMatter.getFluid(200))
                 .output(stickLong, KerrBlackHole)
                 .fluidOutputs(ExoticMatter.getPlasma(500), DarkMatter.getPlasma(250), RedMatter.getPlasma(100))
-                .requireInside(FLUID_SOLIDFICATION_RECIPES, GTValues.UEV, 1)
-                .duration(1200).EUt(VA[UIV]).buildAndRegister();
+                .requireInside(FLUID_SOLIDFICATION_RECIPES, GTValues.UIV, 1)
+                .duration(1200).EUt(VA[UXV]).buildAndRegister();
     }
 }

--- a/src/main/java/dandustry/recipe/HTComponentRecipes.java
+++ b/src/main/java/dandustry/recipe/HTComponentRecipes.java
@@ -8,7 +8,6 @@ import static gregtech.api.GTValues.MAX;
 import static gregtech.api.GTValues.VA;
 import static gregtech.api.recipes.RecipeMaps.ASSEMBLY_LINE_RECIPES;
 import static gregtech.api.unification.material.Materials.RutheniumTriniumAmericiumNeutronate;
-import static gregtech.api.unification.material.Materials.SamariumMagnetic;
 import static gregtech.api.unification.ore.OrePrefix.*;
 import static gregtech.common.items.MetaItems.*;
 
@@ -19,7 +18,7 @@ public class HTComponentRecipes {
         // Motors
 
         ASSEMBLY_LINE_RECIPES.recipeBuilder()
-                .input(stickLong, SamariumMagnetic, 2)
+                .input(stickLong, TengamAttuned)
                 .input(stickLong, HighDurabilityCompoundSteel, 4)
                 .input(ring, FluxedElectrum, 4)
                 .input(round, FluxedElectrum, 8)
@@ -35,7 +34,7 @@ public class HTComponentRecipes {
                 .duration(800).EUt(300000).buildAndRegister();
 
         ASSEMBLY_LINE_RECIPES.recipeBuilder()
-                .input(stickLong, SamariumMagnetic, 4)
+                .input(stickLong, TengamAttuned, 2)
                 .input(stickLong, HastelloyK243, 4)
                 .input(ring, Lafium, 4)
                 .input(round, Lafium, 8)
@@ -51,7 +50,7 @@ public class HTComponentRecipes {
                 .duration(1200).EUt(800000).buildAndRegister();
 
         ASSEMBLY_LINE_RECIPES.recipeBuilder()
-                .input(stickLong, KerrBlackHole)
+                .input(stickLong, TengamAttuned, 4)
                 .input(stickLong, Enderiiium, 4)
                 .input(ring, StellarAlloy, 4)
                 .input(round, StellarAlloy, 8)
@@ -67,7 +66,7 @@ public class HTComponentRecipes {
                 .duration(1600).EUt(2000000).buildAndRegister();
 
         ASSEMBLY_LINE_RECIPES.recipeBuilder()
-                .input(stickLong, KerrBlackHole, 2)
+                .input(stickLong, KerrBlackHole)
                 .input(stickLong, AwakenedDraconium, 4)
                 .input(ring, ChargedDraconium, 4)
                 .input(round, ChargedDraconium, 8)
@@ -83,7 +82,7 @@ public class HTComponentRecipes {
                 .duration(2400).EUt(6000000).buildAndRegister();
 
         ASSEMBLY_LINE_RECIPES.recipeBuilder()
-                .input(stickLong, KerrBlackHole, 4)
+                .input(stickLong, KerrBlackHole, 2)
                 .input(stickLong, Quantum, 4)
                 .input(ring, CallistoIce, 4)
                 .input(round, CallistoIce, 8)
@@ -100,7 +99,7 @@ public class HTComponentRecipes {
                 .duration(3600).EUt(20000000).buildAndRegister();
 
         ASSEMBLY_LINE_RECIPES.recipeBuilder()
-                .input(stickLong, KerrBlackHole, 16)
+                .input(stickLong, KerrBlackHole, 8)
                 .input(stickLong, Floppa, 4)
                 .input(ring, Shirabon, 4)
                 .input(round, Shirabon, 8)

--- a/src/main/java/dandustry/recipe/MiscRecipes.java
+++ b/src/main/java/dandustry/recipe/MiscRecipes.java
@@ -135,5 +135,14 @@ public class MiscRecipes {
                 .fluidInputs(RadoxPolymer.getFluid(4608))
                 .output(TRANSCENDENT_PLASMA_MIXER)
                 .duration(1600).EUt(VA[OpV]).buildAndRegister();
+
+        ELECTROMAGNETIC_SEPARATOR_RECIPES.recipeBuilder()
+                .input(dust, TengamRaw)
+                .chancedOutput(dust, IronMagnetic, 3000,300)
+                .chancedOutput(dust, SteelMagnetic, 2500,300)
+                .chancedOutput(dust, NeodymiumMagnetic, 1800,300)
+                .chancedOutput(dust, SamariumMagnetic, 1500,300)
+                .chancedOutput(dust, TengamPurified, 1200,300)
+                .duration(120).EUt(VA[UV]).buildAndRegister();
     }
 }

--- a/src/main/java/dandustry/recipe/SmallFusionReactorRecipes.java
+++ b/src/main/java/dandustry/recipe/SmallFusionReactorRecipes.java
@@ -126,7 +126,7 @@ public class SmallFusionReactorRecipes {
                 .duration(200).EUt(VA[EV]).buildAndRegister();
 
         ALLOY_SMELTER_RECIPES.recipeBuilder()
-                .input(ingot, Copper, 1).input(ingot, Zinc, 1)
+                .input(ingot, Silver, 1).input(ingot, Magnesium, 1)
                 .output(ingot, Praseodymium, 1)
                 .duration(200).EUt(VA[EV]).buildAndRegister();
 
@@ -196,11 +196,6 @@ public class SmallFusionReactorRecipes {
                 .duration(300).EUt(VA[ZPM] + 1).buildAndRegister();
 
         ALLOY_SMELTER_RECIPES.recipeBuilder()
-                .input(ingot, Yttrium, 1).input(ingot, Dysprosium, 1)
-                .output(ingot, Dubnium, 1)
-                .duration(400).EUt(VA[ZPM] + 2).buildAndRegister();
-
-        ALLOY_SMELTER_RECIPES.recipeBuilder()
                 .input(ingot, Palladium, 1).input(dust, Barium, 1)
                 .output(ingot, Nobelium, 1)
                 .duration(400).EUt(VA[ZPM] + 2).buildAndRegister();
@@ -236,11 +231,6 @@ public class SmallFusionReactorRecipes {
                 .duration(400).EUt(VA[ZPM] + 2).buildAndRegister();
 
         ALLOY_SMELTER_RECIPES.recipeBuilder()
-                .input(ingot, Yttrium, 1).input(ingot, Dysprosium, 1)
-                .output(ingot, Dubnium, 1)
-                .duration(400).EUt(VA[ZPM] + 2).buildAndRegister();
-
-        ALLOY_SMELTER_RECIPES.recipeBuilder()
                 .input(ingot, Actinium, 1).input(ingot, Titanium, 1)
                 .output(ingot, Roentgenium, 1)
                 .duration(400).EUt(VA[ZPM] + 2).buildAndRegister();
@@ -268,11 +258,6 @@ public class SmallFusionReactorRecipes {
         ALLOY_SMELTER_RECIPES.recipeBuilder()
                 .input(ingot, Iridium, 1).input(ingot, Zirconium, 1)
                 .output(ingot, Tennessine, 1)
-                .duration(400).EUt(VA[ZPM] + 2).buildAndRegister();
-
-        ALLOY_SMELTER_RECIPES.recipeBuilder()
-                .input(ingot, Yttrium, 1).input(ingot, Dysprosium, 1)
-                .output(ingot, Dubnium, 1)
                 .duration(400).EUt(VA[ZPM] + 2).buildAndRegister();
 
         ALLOY_SMELTER_RECIPES.recipeBuilder()

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -140,6 +140,9 @@ material.trans_cata_crude=Dimensionally Transcendent Crude Catalyst (DTCC)
 material.trans_cata_excited=Dimensionally Transcendent Excited Catalyst (DTEC)
 material.trans_cata_resplendent=Dimensionally Transcendent Resplendent Catalyst (DTRC)
 material.trans_residue=Dimensionally Transcendent Residue (DTR)
+material.tengam_raw=Raw Tengam
+material.tengam_purified=Purified Tengam
+material.tengam_attuned=Attuned Tengam
 
 dandustry.machine.industrial_laboratory.name=Industrial Laboratory (IL)
 dandustry.machine.transcendent_plasma_mixer.name=Transcendent Plasma Mixer (TPM)

--- a/src/main/resources/assets/gregtech/worldgen/vein/end/tengam_vein.json
+++ b/src/main/resources/assets/gregtech/worldgen/vein/end/tengam_vein.json
@@ -1,0 +1,37 @@
+{
+  "weight": 30,
+  "density": 0.25,
+  "min_height": 10,
+  "max_height": 90,
+  "vein_populator": {
+    "type": "surface_rock",
+    "material": "neodymium"
+  },
+  "dimension_filter": [
+    "name:the_end"
+  ],
+  "generator": {
+    "type": "layered",
+    "radius": [
+      20,
+      24
+    ]
+  },
+  "filler": {
+    "type": "layered",
+    "values": [
+      {
+        "primary": "ore:iron"
+      },
+      {
+        "secondary": "ore:iron"
+      },
+      {
+        "between": "ore:neodymium"
+      },
+      {
+        "sporadic": "ore:tengam_raw"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
We all know the Electromagnetic Separator is the best machine. Raw Tengam Ore doesn't generate because adding an ore vein in an addon requires some very eldritch code. I've decided to wait until this gets made easier in a future update (allegedly hopefully 2.7); someone else can add it if they want to (the ore vein json with the intended data exists). This PR also fixes some recipe conflicts that I stumbled across while adding this.
![image](https://user-images.githubusercontent.com/76633436/233877064-2a3d4865-716c-4abe-a546-0f7fe84f0cac.png)
![image](https://user-images.githubusercontent.com/76633436/233877069-4c312bde-f614-47a5-a21d-2eac2b2b11be.png)
